### PR TITLE
small I2C mux fixes

### DIFF
--- a/drivers/tildagon_i2c/tca9548a.c
+++ b/drivers/tildagon_i2c/tca9548a.c
@@ -4,16 +4,22 @@
 #include "tca9548a.h"
 
 
-void tca9548a_cmd_set_downstream(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port, i2c_cmd_handle_t cmd) {
+esp_err_t tca9548a_cmd_set_downstream(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port) {
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+
     i2c_master_start(cmd);
     i2c_master_write_byte(cmd, self->addr << 1, true);
     i2c_master_write_byte(cmd, (1<<port), true);
-    i2c_master_stop(cmd);   
+    i2c_master_stop(cmd);
+
+    esp_err_t ret = i2c_master_cmd_begin(self->port, cmd, 100 * (3 + 2) / portTICK_PERIOD_MS);
+    i2c_cmd_link_delete(cmd);
+    return ret;
 }
 
 i2c_cmd_handle_t tca9548a_cmd_link_create(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port) {
+    tca9548a_cmd_set_downstream(self, port);
     i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    tca9548a_cmd_set_downstream(self, port, cmd);
     return cmd;
 }
 

--- a/drivers/tildagon_i2c/tca9548a.c
+++ b/drivers/tildagon_i2c/tca9548a.c
@@ -4,7 +4,7 @@
 #include "tca9548a.h"
 
 
-esp_err_t tca9548a_cmd_set_downstream(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port) {
+esp_err_t tca9548a_cmd_set_downstream(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port, TickType_t ticks_to_wait) {
     i2c_cmd_handle_t cmd = i2c_cmd_link_create();
 
     i2c_master_start(cmd);
@@ -12,17 +12,25 @@ esp_err_t tca9548a_cmd_set_downstream(const tca9548a_i2c_mux_t *self, tca9548a_i
     i2c_master_write_byte(cmd, (1<<port), true);
     i2c_master_stop(cmd);
 
-    esp_err_t ret = i2c_master_cmd_begin(self->port, cmd, 100 * (3 + 2) / portTICK_PERIOD_MS);
+    esp_err_t ret = i2c_master_cmd_begin(self->port, cmd, ticks_to_wait);
     i2c_cmd_link_delete(cmd);
     return ret;
 }
 
-i2c_cmd_handle_t tca9548a_cmd_link_create(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port) {
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    return cmd;
-}
-
 esp_err_t tca9548a_master_cmd_begin(const tca9548a_i2c_mux_t *self, i2c_cmd_handle_t cmd, TickType_t ticks_to_wait) {
-    esp_err_t ret = i2c_master_cmd_begin(self->port, cmd, ticks_to_wait);
+    TimeOut_t timeout;
+    vTaskSetTimeOutState(&timeout);
+    if (pdTRUE != xSemaphoreTake(self->mtx, ticks_to_wait) 
+        || pdFALSE != xTaskCheckForTimeOut(&timeout, &ticks_to_wait)) {
+      return ESP_ERR_TIMEOUT;
+    }
+    esp_err_t ret;
+    ret = tca9548a_cmd_set_downstream(self->mux, self->port, ticks_to_wait);
+    if (mux_err != ESP_OK || pdFALSE != xTaskCheckForTimeOut(&timeout, &ticks_to_wait)) {
+        xSemaphoreGive(self->mtx);
+        return ret;
+    }
+    ret = i2c_master_cmd_begin(self->port, cmd, ticks_to_wait);
+    xSemaphoreGive(self->mtx);
     return ret;
 }

--- a/drivers/tildagon_i2c/tca9548a.c
+++ b/drivers/tildagon_i2c/tca9548a.c
@@ -18,7 +18,6 @@ esp_err_t tca9548a_cmd_set_downstream(const tca9548a_i2c_mux_t *self, tca9548a_i
 }
 
 i2c_cmd_handle_t tca9548a_cmd_link_create(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port) {
-    tca9548a_cmd_set_downstream(self, port);
     i2c_cmd_handle_t cmd = i2c_cmd_link_create();
     return cmd;
 }

--- a/drivers/tildagon_i2c/tca9548a.c
+++ b/drivers/tildagon_i2c/tca9548a.c
@@ -17,7 +17,7 @@ esp_err_t tca9548a_cmd_set_downstream(const tca9548a_i2c_mux_t *self, tca9548a_i
     return ret;
 }
 
-esp_err_t tca9548a_master_cmd_begin(const tca9548a_i2c_mux_t *self, i2c_cmd_handle_t cmd, TickType_t ticks_to_wait) {
+esp_err_t tca9548a_master_cmd_begin(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port, i2c_cmd_handle_t cmd, TickType_t ticks_to_wait) {
     TimeOut_t timeout;
     vTaskSetTimeOutState(&timeout);
     if (pdTRUE != xSemaphoreTake(self->mtx, ticks_to_wait) 
@@ -25,7 +25,7 @@ esp_err_t tca9548a_master_cmd_begin(const tca9548a_i2c_mux_t *self, i2c_cmd_hand
       return ESP_ERR_TIMEOUT;
     }
     esp_err_t ret;
-    ret = tca9548a_cmd_set_downstream(self->mux, self->port, ticks_to_wait);
+    ret = tca9548a_cmd_set_downstream(self->mux, port, ticks_to_wait);
     if (mux_err != ESP_OK || pdFALSE != xTaskCheckForTimeOut(&timeout, &ticks_to_wait)) {
         xSemaphoreGive(self->mtx);
         return ret;

--- a/drivers/tildagon_i2c/tca9548a.c
+++ b/drivers/tildagon_i2c/tca9548a.c
@@ -35,12 +35,12 @@ esp_err_t tca9548a_master_cmd_begin(const tca9548a_i2c_mux_t *self, tca9548a_i2c
     }
     esp_err_t ret;
     if (port != self->active_port) {
-        ret = tca9548a_cmd_set_downstream(self->mux, port, ticks_to_wait);
-        if (mux_err != ESP_OK || pdFALSE != xTaskCheckForTimeOut(&timeout, &ticks_to_wait)) {
+        ret = tca9548a_cmd_set_downstream(self, port, ticks_to_wait);
+        if (ret != ESP_OK || pdFALSE != xTaskCheckForTimeOut(&timeout, &ticks_to_wait)) {
             xSemaphoreGive(self->mtx);
             return ret;
         }
-        self->active_port = port;
+        ((tca9548a_i2c_mux_t*)self)->active_port = port;
     }
     ret = i2c_master_cmd_begin(self->port, cmd, ticks_to_wait);
     xSemaphoreGive(self->mtx);

--- a/drivers/tildagon_i2c/tca9548a.h
+++ b/drivers/tildagon_i2c/tca9548a.h
@@ -17,7 +17,7 @@ typedef unsigned char tca9548a_i2c_port_t;
  * tca9548a_cmd_link_create
  * 
  * Similar to i2c_cmd_link_create - creates an i2c_cmd_handle_t
- * and additionally adds a command to set the downstream port.
+ * and additionally performs a transaction to set the downstream port.
  * This function is thread-safe and can be called from any thread.
  * Be aware that a longer timeout may be needed if the bus is busy!
  *
@@ -38,4 +38,14 @@ i2c_cmd_handle_t tca9548a_cmd_link_create(const tca9548a_i2c_mux_t *self, tca954
 */
 esp_err_t tca9548a_master_cmd_begin(const tca9548a_i2c_mux_t *self, i2c_cmd_handle_t cmd, TickType_t ticks_to_wait);
 
+/**
+ * tca9548a_cmd_set_downstream
+ * 
+ * Enables the specified downstream port on the I2C provided i2c mux.
+ * Only one port is active at a time.
+ * 
+ * @param self - mux object to set the downstream port for
+ * @param port - the port to switch to
+*/
+esp_err_t tca9548a_cmd_set_downstream(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port);
 #endif // _TCA9548A_H

--- a/drivers/tildagon_i2c/tca9548a.h
+++ b/drivers/tildagon_i2c/tca9548a.h
@@ -21,10 +21,11 @@ typedef unsigned char tca9548a_i2c_port_t;
  * on the bus upstream of the i2c mux. Additionally sets the downstream MUX port.
  * 
  * @param self - mux object to begin the i2c transactions for
+ * @param port - the downstream port to set
  * @param cmd - command link to send
  * @param ticks_to_wait - maximum timeout
 */
-esp_err_t tca9548a_master_cmd_begin(const tca9548a_i2c_mux_t *self, i2c_cmd_handle_t cmd, TickType_t ticks_to_wait);
+esp_err_t tca9548a_master_cmd_begin(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port, i2c_cmd_handle_t cmd, TickType_t ticks_to_wait);
 
 /**
  * tca9548a_cmd_set_downstream

--- a/drivers/tildagon_i2c/tca9548a.h
+++ b/drivers/tildagon_i2c/tca9548a.h
@@ -6,13 +6,15 @@
 
 #include "freertos/semphr.h"
 
+typedef unsigned char tca9548a_i2c_port_t;
+
 typedef struct _tca9548a_i2c_mux {
   i2c_port_t port : 8;
   uint16_t addr;
   SemaphoreHandle_t mtx;
+  tca9548a_i2c_port_t active_port;
 } tca9548a_i2c_mux_t;
 
-typedef unsigned char tca9548a_i2c_port_t;
 
 /**
  * tca9548a_master_cmd_begin
@@ -27,14 +29,4 @@ typedef unsigned char tca9548a_i2c_port_t;
 */
 esp_err_t tca9548a_master_cmd_begin(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port, i2c_cmd_handle_t cmd, TickType_t ticks_to_wait);
 
-/**
- * tca9548a_cmd_set_downstream
- * 
- * Enables the specified downstream port on the I2C provided i2c mux.
- * Only one port is active at a time.
- * 
- * @param self - mux object to set the downstream port for
- * @param port - the port to switch to
-*/
-esp_err_t tca9548a_cmd_set_downstream(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port);
 #endif // _TCA9548A_H

--- a/drivers/tildagon_i2c/tca9548a.h
+++ b/drivers/tildagon_i2c/tca9548a.h
@@ -4,6 +4,8 @@
 #include "driver/i2c.h"
 #include "hal/i2c_ll.h"
 
+#include "freertos/semphr.h"
+
 typedef struct _tca9548a_i2c_mux {
   i2c_port_t port : 8;
   uint16_t addr;
@@ -12,25 +14,11 @@ typedef struct _tca9548a_i2c_mux {
 
 typedef unsigned char tca9548a_i2c_port_t;
 
-
-/**
- * tca9548a_cmd_link_create
- * 
- * Similar to i2c_cmd_link_create - creates an i2c_cmd_handle_t
- * and additionally performs a transaction to set the downstream port.
- * This function is thread-safe and can be called from any thread.
- * Be aware that a longer timeout may be needed if the bus is busy!
- *
- * @param self - mux object to create the link for
- * @param port - downstream port number to use
-*/
-i2c_cmd_handle_t tca9548a_cmd_link_create(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port);
-
 /**
  * tca9548a_master_cmd_begin
  *
  * similar to i2c_master_cmd_begin - begins a sequence of I2C transactions
- * on the bus upstream of the i2c mux.
+ * on the bus upstream of the i2c mux. Additionally sets the downstream MUX port.
  * 
  * @param self - mux object to begin the i2c transactions for
  * @param cmd - command link to send

--- a/drivers/tildagon_i2c/tildagon_i2c.c
+++ b/drivers/tildagon_i2c/tildagon_i2c.c
@@ -64,9 +64,6 @@ const tca9548a_i2c_mux_t *tildagon_get_i2c_mux() {
 
 void tildagon_i2c_init() {
     tildagon_i2c_mux.mtx = xSemaphoreCreateMutex();
-    if (tildagon_i2c_mux.mtx == NULL) {
-      return NULL;
-    }
     xSemaphoreGive(&tildagon_i2c_mux.mtx);
     tildagon_i2c_mux.addr = 0x77;
     tildagon_i2c_mux.active_port = -1;

--- a/drivers/tildagon_i2c/tildagon_i2c.c
+++ b/drivers/tildagon_i2c/tildagon_i2c.c
@@ -69,6 +69,7 @@ void tildagon_i2c_init() {
     }
     xSemaphoreGive(&tildagon_i2c_mux.mtx);
     tildagon_i2c_mux.addr = 0x77;
+    tildagon_i2c_mux.active_port = -1;
     
     i2c_config_t conf = {
         .mode = I2C_MODE_MASTER,

--- a/drivers/tildagon_i2c/tildagon_i2c.c
+++ b/drivers/tildagon_i2c/tildagon_i2c.c
@@ -64,7 +64,6 @@ const tca9548a_i2c_mux_t *tildagon_get_i2c_mux() {
 
 void tildagon_i2c_init() {
     tildagon_i2c_mux.mtx = xSemaphoreCreateMutex();
-    xSemaphoreGive(&tildagon_i2c_mux.mtx);
     tildagon_i2c_mux.addr = 0x77;
     tildagon_i2c_mux.active_port = -1;
     

--- a/drivers/tildagon_i2c/tildagon_i2c.c
+++ b/drivers/tildagon_i2c/tildagon_i2c.c
@@ -85,6 +85,12 @@ int tildagon_mux_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, m
     if (addr == self->mux->addr) {
         return -MP_ENODEV;
     }
+    
+    esp_err_t mux_err = tca9548a_cmd_set_downstream(self->mux, self->port);
+    if (mux_err != ESP_OK) {
+        // TODO: not sure what error would be the right one to return here
+        return -abs(mux_err);
+    }
 
     i2c_cmd_handle_t cmd = tca9548a_cmd_link_create(self->mux, self->port);
     int data_len = 0;

--- a/drivers/tildagon_i2c/tildagon_i2c.c
+++ b/drivers/tildagon_i2c/tildagon_i2c.c
@@ -155,7 +155,7 @@ mp_obj_t tildagon_mux_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
     // Get I2C bus
     mp_int_t i2c_id = mp_obj_get_int(args[ARG_id].u_obj);
-    if (!(MP_I2C_MUX_PORT_MIN <= i2c_id && i2c_id < MP_I2C_MUX_PORT_MAX)) {
+    if (!(MP_I2C_MUX_PORT_MIN <= i2c_id && i2c_id <= MP_I2C_MUX_PORT_MAX)) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }
 

--- a/drivers/tildagon_i2c/tildagon_i2c.c
+++ b/drivers/tildagon_i2c/tildagon_i2c.c
@@ -123,7 +123,7 @@ int tildagon_mux_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, m
     }
 
     // TODO proper timeout
-    esp_err_t err = tca9548a_master_cmd_begin(self->mux, cmd, 100 * (3 + data_len) / portTICK_PERIOD_MS);
+    esp_err_t err = tca9548a_master_cmd_begin(self->mux, self->port, cmd, 100 * (3 + data_len) / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
 
     if (err == ESP_FAIL) {

--- a/drivers/tildagon_i2c/tildagon_i2c.h
+++ b/drivers/tildagon_i2c/tildagon_i2c.h
@@ -9,8 +9,8 @@
 #error "unsupported I2C for ESP32 SoC variant"
 #endif
 
-#define TILDAGON_HOST_I2C_SDA (8)
-#define TILDAGON_HOST_I2C_SCL (9)
+#define TILDAGON_HOST_I2C_SDA (45)
+#define TILDAGON_HOST_I2C_SCL (46)
 #define TILDAGON_HOST_I2C_FREQ (400000)
 #define TILDAGON_HOST_I2C_PORT (0)
 #define TILDAGON_HOST_I2C_TIMEOUT (50000)


### PR DESCRIPTION
Hi Skyler,

Here are the changes I needed to do to get the badge talking to i2c devices on the hexpansion ports. I was able to successfully talk to an i2c eeprom after configuring the gpio expanders to enable power to the hexpansion slots.

One small thing I haven't done yet is handling errors that might happen when switching the downstream port. I could take the cmd_set_downstream out of cmd_link_create to make it easier but I wasn't sure what would be the neatest way to do it. 

